### PR TITLE
Refactor the Gmail Utility to check if a header is present without throwing error

### DIFF
--- a/src/main/java/com/google/sps/utility/GmailUtility.java
+++ b/src/main/java/com/google/sps/utility/GmailUtility.java
@@ -29,7 +29,7 @@ public final class GmailUtility {
   private static final Pattern fromHeaderPattern = Pattern.compile("(.*)?<(.*)>");
 
   /**
-   * Given a list of message headers, extract a single header with the specified name
+   * Given a message object, extract a single header with the specified name
    *
    * @param message a Gmail message object. Must be METADATA or FULL format
    * @param headerName name of header that should be extracted
@@ -55,6 +55,26 @@ public final class GmailUtility {
             () ->
                 new GmailMessageFormatException(
                     String.format("%s Header not present!", headerName)));
+  }
+
+  /**
+   * Given a message object, check if a header is present
+   *
+   * @param message a Gmail message object to be checked
+   * @param headerName name of the header that should be queried
+   * @return true if present, false otherwise
+   */
+  public static boolean hasHeader(Message message, String headerName) {
+    MessagePart payload = message.getPayload();
+    if (payload == null) {
+      return false;
+    }
+    List<MessagePartHeader> headers = payload.getHeaders();
+    if (headers == null || headers.isEmpty()) {
+      return false;
+    }
+
+    return headers.stream().anyMatch((header) -> header.getName().equals(headerName));
   }
 
   /**

--- a/src/test/java/GmailUtilityTest.java
+++ b/src/test/java/GmailUtilityTest.java
@@ -101,4 +101,24 @@ public final class GmailUtilityTest {
   public void extractNameInFromHeaderWhenHeaderInvalid() {
     GmailUtility.parseNameInFromHeader("");
   }
+
+  @Test
+  public void hasHeaderMessageHasNoPayload() {
+    Assert.assertEquals(false, GmailUtility.hasHeader(messageNoPayload, HEADER_NAME));
+  }
+
+  @Test
+  public void hasHeaderMessageHasNoHeaders() {
+    Assert.assertEquals(false, GmailUtility.hasHeader(messageNoHeaders, HEADER_NAME));
+  }
+
+  @Test
+  public void hasHeaderIsNotPresent() {
+    Assert.assertEquals(false, GmailUtility.hasHeader(messageWithoutHeaderName, HEADER_NAME));
+  }
+
+  @Test
+  public void hasHeaderIsPresent() {
+    Assert.assertEquals(true, GmailUtility.hasHeader(messageWithHeaderName, HEADER_NAME));
+  }
 }


### PR DESCRIPTION
Required for checking the "List-ID" header in PR #139 